### PR TITLE
feat: add and show game board

### DIFF
--- a/lib/game_board/board_widget.dart
+++ b/lib/game_board/board_widget.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/material.dart';
+
+class GameBoardWidget extends StatefulWidget {
+  const GameBoardWidget({super.key});
+
+  @override
+  State<GameBoardWidget> createState() => _GameBoardWidgetState();
+}
+
+class _GameBoardWidgetState extends State<GameBoardWidget> {
+  final int crossAxisCount = 10;
+  final int tileTotal = 100;
+  final tileKeys = List.generate(100, (index) => GlobalKey());
+
+  @override
+  Widget build(BuildContext context) {
+    return GridView.builder(
+      gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+        crossAxisCount: crossAxisCount,
+      ),
+      itemCount: tileTotal,
+      itemBuilder: (context, realIndex) {
+        final row = realIndex ~/ crossAxisCount;
+        final column = realIndex % crossAxisCount;
+
+        int index = 0;
+
+        if (row % 2 == 0) {
+          index = row * crossAxisCount + column;
+        } else {
+          index = row * crossAxisCount + (crossAxisCount - column - 1);
+        }
+
+        return Container(
+          key: tileKeys[index],
+          decoration: BoxDecoration(border: Border.all(color: Colors.black38)),
+          child: Align(
+            alignment: Alignment.topLeft,
+            child: Text(index.toString()),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:snakes_and_ladders/snakes_and_ladders/snakes_and_ladders_page.dart';
 
 void main() {
   runApp(const MainApp());
@@ -9,12 +10,6 @@ class MainApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const MaterialApp(
-      home: Scaffold(
-        body: Center(
-          child: Text('Hello World!'),
-        ),
-      ),
-    );
+    return const MaterialApp(home: Scaffold(body: SnakesAndLaddersPage()));
   }
 }

--- a/lib/snakes_and_ladders/snakes_and_ladders_page.dart
+++ b/lib/snakes_and_ladders/snakes_and_ladders_page.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+
+import '../game_board/board_widget.dart';
+
+class SnakesAndLaddersPage extends StatefulWidget {
+  const SnakesAndLaddersPage({super.key});
+
+  @override
+  State<SnakesAndLaddersPage> createState() => _SnakesAndLaddersPageState();
+}
+
+class _SnakesAndLaddersPageState extends State<SnakesAndLaddersPage> {
+  @override
+  Widget build(BuildContext context) {
+    return Stack(children: [GameBoardWidget()]);
+  }
+}


### PR DESCRIPTION
# Deskripsi Perubahan

Code ini mengimplementasikan `GridView.builder` untuk mengenerate tiles board dan logika untuk menampilkan elemen dalam pola zig-zag pada grid dengan sejumlah kolom tertentu yang nanti akan dijadikan posisi asli tiles.

Penjelasan:

- `itemBuilder` menerima parameter `index` yang menunjukkan posisi item saat ini.
- `row` dihitung dengan membagi `index` dengan jumlah kolom (`columns`), menunjukkan baris item.
- `col` adalah sisa pembagian `index` dengan `columns`, menunjukkan kolom item pada baris tersebut.
- Untuk membuat pola zig-zag:
  - Jika baris (`row`) genap, item ditampilkan dari kiri ke kanan dengan menghitung `displayIndex` menggunakan rumus:  
    `displayIndex = row * columns + col`
  - Jika baris ganjil, item ditampilkan dari kanan ke kiri dengan menghitung `displayIndex` menggunakan rumus:  
    `displayIndex = row * columns + (columns - col - 1)`
- Penjelasan rumus untuk baris ganjil:  
  `(columns - col - 1)` membalik posisi kolom sehingga indeks kolom dihitung dari ujung kanan ke kiri, bukan kiri ke kanan.  
  Contohnya, jika ada 5 kolom dan `col` = 0 (kolom paling kiri), maka indeks yang digunakan adalah `5 - 0 - 1 = 4` (kolom paling kanan).
- `displayIndex` ini menentukan item mana yang akan ditampilkan di posisi saat ini sehingga menghasilkan pola zig-zag.
- Setiap item ditampilkan dalam `Container` dengan warna biru muda dan teks yang menunjukkan `displayIndex`.

Tujuan perubahan ini adalah untuk mengatur tata letak grid dengan pola zig-zag, sehingga baris ganjil membalik urutan item dibandingkan baris genap.